### PR TITLE
hot lib is not initialized corretion

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -77,20 +77,31 @@ function init() {
 }
 
 function callCreator(command, ...args) {
-  if (!command) return console.error("command not valid!");
+  if (!command) {
+    console.error("command not valid!");
+    return;
+  }
   const { method, hasParams } = commandOptionsMap[command];
-  if (hasParams) {
-    isInitialized();
-    method(args);
-  } else {
-    method();
+
+  try {
+    if (isInitialized()) {
+      if (hasParams) {
+        method(args);
+      } else {
+        method();
+      }
+    }
+  } catch (error) {
+    console.error(error.message);
+    return;
   }
 }
 
 function isInitialized() {
-  if (!fs.existsSync(configFilePath))
-    console.error("lib is not initialized or config file its not on root");
-  return false;
+  if (!fs.existsSync(configFilePath)) {
+    throw new Error("lib is not initialized or config file its not on root");
+  }
+  return true;
 }
 
 function getConfigFileContent() {


### PR DESCRIPTION
Este PR implementa uma verificação de inicialização na biblioteca, garantindo que os comandos de criação de arquivos (create:model e create:controller) só sejam executados se a biblioteca estiver corretamente inicializada